### PR TITLE
Fixed Fiji printing methods

### DIFF
--- a/juav-copter/src/main/java/ub/cse/juav/copter/Copter.java
+++ b/juav-copter/src/main/java/ub/cse/juav/copter/Copter.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class Copter {
     Map<Integer,Mode> modes;
-    public static boolean LOG_TIMING = true;
+    public static boolean LOG_TIMING = false;
 
     public void setModes(Map<Integer,Mode> modes) {
         this.modes = modes;

--- a/juav-copter/src/main/java/ub/cse/juav/copter/Copter.java
+++ b/juav-copter/src/main/java/ub/cse/juav/copter/Copter.java
@@ -2,12 +2,13 @@ package ub.cse.juav.copter;
 
 import ub.cse.juav.copter.modes.Mode;
 import ub.cse.juav.jni.ArdupilotNativeWrapper;
-
+import com.fiji.fivm.r1.fivmRuntime;
+import ub.cse.juav.jni.FijiJniSwitch;
 import java.util.Map;
 
 public class Copter {
     Map<Integer,Mode> modes;
-    public static boolean LOG_TIMING = false;
+    public static boolean LOG_TIMING = true;
 
     public void setModes(Map<Integer,Mode> modes) {
         this.modes = modes;
@@ -35,7 +36,12 @@ public class Copter {
             long time1 = System.nanoTime();
             modes.get(mode).run();
             long time2 = System.nanoTime();
-            if (this.LOG_TIMING) {
+            if (FijiJniSwitch.usingFiji) {
+		fivmRuntime.logPrint(Long.toString(time1));
+		fivmRuntime.logPrint(", ");
+		fivmRuntime.logPrint(Long.toString(time2));
+		fivmRuntime.logPrint("\n");
+            } else {
                 System.out.format("%d, %d\n", time1, time2);
             }
         } else {

--- a/juav-copter/src/main/java/ub/cse/juav/copter/Copter.java
+++ b/juav-copter/src/main/java/ub/cse/juav/copter/Copter.java
@@ -36,13 +36,15 @@ public class Copter {
             long time1 = System.nanoTime();
             modes.get(mode).run();
             long time2 = System.nanoTime();
-            if (FijiJniSwitch.usingFiji) {
-		fivmRuntime.logPrint(Long.toString(time1));
-		fivmRuntime.logPrint(", ");
-		fivmRuntime.logPrint(Long.toString(time2));
-		fivmRuntime.logPrint("\n");
-            } else {
-                System.out.format("%d, %d\n", time1, time2);
+            if (this.LOG_TIMING) {
+                if (FijiJniSwitch.usingFiji) {
+		    fivmRuntime.logPrint(Long.toString(time1));
+		    fivmRuntime.logPrint(", ");
+		    fivmRuntime.logPrint(Long.toString(time2));
+		    fivmRuntime.logPrint("\n");
+                } else {
+                    System.out.format("%d, %d\n", time1, time2);
+                }
             }
         } else {
             callNativeMode();

--- a/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeAuto.java
+++ b/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeAuto.java
@@ -3,6 +3,9 @@ package ub.cse.juav.copter.modes;
 import ub.cse.juav.copter.AcAttitudeControl;
 import ub.cse.juav.jni.ArdupilotNative;
 import ub.cse.juav.jni.ArdupilotNativeWrapper;
+import com.fiji.fivm.r1.fivmRuntime;
+import ub.cse.juav.jni.FijiJniSwitch;
+import ub.cse.juav.copter.Copter;
 
 public class ModeAuto extends Mode{
 
@@ -25,6 +28,7 @@ public class ModeAuto extends Mode{
     @Override
     public void run() {
         // call the correct auto controller
+        long time1 = System.nanoTime();
         switch (getCurrentAutoMode()) {
 
             case 0:
@@ -68,6 +72,18 @@ public class ModeAuto extends Mode{
             case 10:
                 payloadPlaceRun();
                 break;
+        }
+	long time2 = System.nanoTime();
+        if (Copter.LOG_TIMING) {
+            if (FijiJniSwitch.usingFiji) {
+		fivmRuntime.logPrint("Auto: ");
+		fivmRuntime.logPrint(Long.toString(time1));
+		fivmRuntime.logPrint(", ");
+		fivmRuntime.logPrint(Long.toString(time2));
+		fivmRuntime.logPrint(", ");
+            } else {
+                System.out.format("Auto: %d, %d, ", time1, time2);
+            }
         }
     }
 

--- a/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeGuided.java
+++ b/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeGuided.java
@@ -54,7 +54,11 @@ public class ModeGuided extends Mode{
         long time2 = System.nanoTime();
         if (Copter.LOG_TIMING) {
             if (FijiJniSwitch.usingFiji) {
-		fivmRuntime.logPrint(String.format("Guided: %d, %d, ", time1, time2));
+		fivmRuntime.logPrint("Guided: ");
+		fivmRuntime.logPrint(Long.toString(time1));
+		fivmRuntime.logPrint(", ");
+		fivmRuntime.logPrint(Long.toString(time2));
+		fivmRuntime.logPrint(", ");
             } else {
                 System.out.format("Guided: %d, %d, ", time1, time2);
             }

--- a/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeLoiter.java
+++ b/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeLoiter.java
@@ -28,7 +28,11 @@ public class ModeLoiter extends Mode {
 	long time2 = System.nanoTime();
         if (Copter.LOG_TIMING) {
             if (FijiJniSwitch.usingFiji) {
-		fivmRuntime.logPrint(String.format("Loiter: %d, %d, ", time1, time2));
+		fivmRuntime.logPrint("Loiter: ");
+		fivmRuntime.logPrint(Long.toString(time1));
+		fivmRuntime.logPrint(", ");
+		fivmRuntime.logPrint(Long.toString(time2));
+		fivmRuntime.logPrint(", ");
             } else {
                 System.out.format("Loiter: %d, %d, ", time1, time2);
             }

--- a/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeStabilize.java
+++ b/juav-copter/src/main/java/ub/cse/juav/copter/modes/ModeStabilize.java
@@ -31,7 +31,11 @@ public class ModeStabilize extends Mode{
         long time2 = System.nanoTime();
 	if (Copter.LOG_TIMING) {
             if (FijiJniSwitch.usingFiji) {
-		fivmRuntime.logPrint(String.format("Stabilize: %d, %d, ", time1, time2));
+		fivmRuntime.logPrint("Stabilize: ");
+		fivmRuntime.logPrint(Long.toString(time1));
+		fivmRuntime.logPrint(", ");
+		fivmRuntime.logPrint(Long.toString(time2));
+		fivmRuntime.logPrint(", ");
             } else {
                 System.out.format("Stabilize: %d, %d, ", time1, time2);
             }


### PR DESCRIPTION
The previous way that I printed (using string:format) was causing errors cause fiji did not have access to this method. Instead I use long.toString() to print the timing stats